### PR TITLE
[codex] create-chat-session

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,10 +24,12 @@ def create_app():
     from pdf_ai_agent.api.routes.auth import router as auth_router
     from pdf_ai_agent.api.routes.documents import router as documents_router
     from pdf_ai_agent.api.routes.notes import router as notes_router
+    from pdf_ai_agent.api.routes.chat_sessions import router as chat_sessions_router
     
     app.include_router(auth_router)
     app.include_router(documents_router)
     app.include_router(notes_router)
+    app.include_router(chat_sessions_router)
     
     @app.get("/health", tags=["Health Check"])
     async def health_check():

--- a/src/pdf_ai_agent/api/routes/chat_sessions.py
+++ b/src/pdf_ai_agent/api/routes/chat_sessions.py
@@ -1,0 +1,107 @@
+"""
+Chat session routes.
+"""
+
+import logging
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from pdf_ai_agent.api.schemas.chat_schemas import (
+    ChatSessionContext,
+    ChatDefaults,
+    CreateChatSessionRequest,
+    CreateChatSessionResponse,
+    ChatErrorResponse,
+    ChatSessionData,
+)
+from pdf_ai_agent.api.services.chat_session_service import ChatSessionService
+from pdf_ai_agent.config.database.init_database import get_db_session
+
+router = APIRouter(prefix="/api/workspaces", tags=["Chat Sessions"])
+logger = logging.getLogger(__name__)
+
+
+def get_chat_session_service(
+    session: AsyncSession = Depends(get_db_session),
+) -> ChatSessionService:
+    """Get ChatSessionService instance."""
+    return ChatSessionService(db_session=session)
+
+
+@router.post(
+    "/{workspace_id}/chat/sessions",
+    response_model=CreateChatSessionResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        400: {"model": ChatErrorResponse, "description": "Invalid request"},
+        403: {"model": ChatErrorResponse, "description": "Forbidden - no access to workspace"},
+        404: {"model": ChatErrorResponse, "description": "Workspace/note/doc not found"},
+        409: {"model": ChatErrorResponse, "description": "client_request_id already used"},
+        422: {"model": ChatErrorResponse, "description": "Anchor validation failed"},
+        500: {"model": ChatErrorResponse, "description": "Internal server error"},
+    },
+)
+async def create_chat_session(
+    request: CreateChatSessionRequest,
+    workspace_id: int = Path(..., description="Workspace ID", gt=0),
+    user_id: int = Query(..., description="User ID (dev mode)"),
+    chat_service: ChatSessionService = Depends(get_chat_session_service),
+):
+    """
+    Create a new chat session in a workspace.
+
+    **Authentication (Dev Mode):**
+    - Requires `user_id` in query parameter
+
+    **Validation:**
+    - User must have access to workspace (member+)
+    - mode must be ask|assist|agent
+    - defaults must be within allowed ranges
+    - context note/doc/anchor ownership is enforced
+    """
+    try:
+        session_model = await chat_service.create_session(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            title=request.title,
+            mode=request.mode.value if request.mode else None,
+            context=request.context.model_dump() if request.context else None,
+            defaults=request.defaults.model_dump() if request.defaults else None,
+            client_request_id=request.client_request_id,
+        )
+
+        context_payload = session_model.context_json or {
+            "note_id": None,
+            "anchor_ids": [],
+            "doc_id": None,
+            "doc_anchor_ids": [],
+        }
+        defaults_payload = session_model.defaults_json or {
+            "model": "gpt-4.1-mini",
+            "temperature": 0.2,
+            "top_p": 1.0,
+            "system_prompt": None,
+            "retrieval": {"enabled": True, "top_k": 8, "rerank": False},
+        }
+
+        session_data = ChatSessionData(
+            id=session_model.session_id,
+            workspace_id=session_model.workspace_id,
+            title=session_model.title,
+            mode=session_model.mode,
+            context=ChatSessionContext(**context_payload),
+            defaults=ChatDefaults(**defaults_payload),
+            created_at=session_model.created_at,
+            updated_at=session_model.updated_at,
+        )
+
+        return CreateChatSessionResponse(session=session_data)
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Unexpected error in create_chat_session: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="INTERNAL_ERROR: An unexpected error occurred",
+        )

--- a/src/pdf_ai_agent/api/schemas/chat_schemas.py
+++ b/src/pdf_ai_agent/api/schemas/chat_schemas.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ChatSessionMode(str, Enum):
+    """Chat session modes."""
+    ASK = "ask"
+    ASSIST = "assist"
+    AGENT = "agent"
+
+
+class ChatSessionContext(BaseModel):
+    """Context for a chat session."""
+    note_id: Optional[int] = Field(None, description="Note ID")
+    anchor_ids: Optional[List[int]] = Field(None, description="Anchor IDs for note context")
+    doc_id: Optional[int] = Field(None, description="Document ID")
+    doc_anchor_ids: Optional[List[int]] = Field(None, description="Anchor IDs for document context")
+
+
+class RetrievalDefaults(BaseModel):
+    """Retrieval defaults."""
+    enabled: bool = Field(True, description="Enable retrieval")
+    top_k: int = Field(8, description="Number of chunks to retrieve")
+    rerank: bool = Field(False, description="Enable reranking")
+
+
+class ChatDefaults(BaseModel):
+    """Default chat settings."""
+    model: str = Field("gpt-4.1-mini", description="Model name")
+    temperature: float = Field(0.2, description="Sampling temperature")
+    top_p: float = Field(1.0, description="Top-p sampling")
+    system_prompt: Optional[str] = Field(None, description="System prompt")
+    retrieval: RetrievalDefaults = Field(default_factory=RetrievalDefaults)
+
+
+class CreateChatSessionRequest(BaseModel):
+    """Request schema for creating a chat session."""
+    title: Optional[str] = Field(None, description="Optional chat title")
+    mode: ChatSessionMode = Field(ChatSessionMode.ASK, description="Chat mode")
+    context: Optional[ChatSessionContext] = Field(None, description="Chat context")
+    defaults: Optional[ChatDefaults] = Field(None, description="Default settings")
+    client_request_id: Optional[str] = Field(None, description="Client request ID for idempotency")
+
+
+class ChatSessionData(BaseModel):
+    """Chat session response payload."""
+    id: int = Field(..., description="Session ID")
+    workspace_id: int = Field(..., description="Workspace ID")
+    title: str = Field(..., description="Chat title")
+    mode: ChatSessionMode = Field(..., description="Chat mode")
+    context: ChatSessionContext = Field(..., description="Chat context")
+    defaults: ChatDefaults = Field(..., description="Chat defaults")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Update timestamp")
+
+
+class CreateChatSessionResponse(BaseModel):
+    """Response schema for creating a chat session."""
+    session: ChatSessionData = Field(..., description="Chat session data")
+
+
+class ChatErrorCode(str, Enum):
+    """Error codes for chat session operations."""
+    FORBIDDEN = "FORBIDDEN"
+    INVALID_ARGUMENT = "INVALID_ARGUMENT"
+    WORKSPACE_NOT_FOUND = "WORKSPACE_NOT_FOUND"
+    NOTE_NOT_FOUND = "NOTE_NOT_FOUND"
+    DOC_NOT_FOUND = "DOC_NOT_FOUND"
+    ANCHOR_INVALID = "ANCHOR_INVALID"
+    CLIENT_REQUEST_ID_CONFLICT = "CLIENT_REQUEST_ID_CONFLICT"
+
+
+class ChatErrorDetail(BaseModel):
+    """Error detail schema."""
+    code: ChatErrorCode = Field(..., description="Error code")
+    message: str = Field(..., description="Error message")
+
+
+class ChatErrorResponse(BaseModel):
+    """Error response schema."""
+    error: ChatErrorDetail = Field(..., description="Error details")

--- a/src/pdf_ai_agent/api/services/chat_session_service.py
+++ b/src/pdf_ai_agent/api/services/chat_session_service.py
@@ -1,0 +1,338 @@
+"""
+Chat session service for creating chat sessions.
+"""
+
+import logging
+from copy import deepcopy
+from typing import Any, Dict, Iterable, Optional
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from pdf_ai_agent.api.utilties.workspace_utils import check_workspace_membership
+from pdf_ai_agent.config.database.models.model_document import (
+    AnchorModel,
+    ChatSessionModel,
+    ChatSessionModeEnum,
+    DocsModel,
+    NoteModel,
+)
+from pdf_ai_agent.config.database.models.model_user import WorkspaceModel
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TITLE = "New chat"
+ALLOWED_MODELS = {"gpt-4.1-mini"}
+
+DEFAULT_RETRIEVAL: Dict[str, Any] = {
+    "enabled": True,
+    "top_k": 8,
+    "rerank": False,
+}
+
+DEFAULT_DEFAULTS: Dict[str, Any] = {
+    "model": "gpt-4.1-mini",
+    "temperature": 0.2,
+    "top_p": 1.0,
+    "system_prompt": None,
+    "retrieval": DEFAULT_RETRIEVAL,
+}
+
+
+class ChatSessionService:
+    """Service for chat session operations."""
+
+    def __init__(self, db_session: AsyncSession):
+        self.db_session = db_session
+
+    async def _get_workspace(self, workspace_id: int) -> Optional[WorkspaceModel]:
+        query = select(WorkspaceModel).where(WorkspaceModel.workspace_id == workspace_id)
+        result = await self.db_session.execute(query)
+        return result.scalar_one_or_none()
+
+    async def _get_note(self, note_id: int) -> Optional[NoteModel]:
+        query = select(NoteModel).where(NoteModel.note_id == note_id)
+        result = await self.db_session.execute(query)
+        return result.scalar_one_or_none()
+
+    async def _get_doc(self, doc_id: int) -> Optional[DocsModel]:
+        query = select(DocsModel).where(DocsModel.doc_id == doc_id)
+        result = await self.db_session.execute(query)
+        return result.scalar_one_or_none()
+
+    async def _load_anchors(self, anchor_ids: Iterable[int]) -> Dict[int, AnchorModel]:
+        anchor_list = list({int(anchor_id) for anchor_id in anchor_ids})
+        if not anchor_list:
+            return {}
+        query = select(AnchorModel).where(AnchorModel.anchor_id.in_(anchor_list))
+        result = await self.db_session.execute(query)
+        anchors = result.scalars().all()
+        if len(anchors) != len(anchor_list):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="ANCHOR_INVALID: One or more anchors not found",
+            )
+        return {anchor.anchor_id: anchor for anchor in anchors}
+
+    @staticmethod
+    def _normalize_title(title: Optional[str]) -> str:
+        if not title or not title.strip():
+            return DEFAULT_TITLE
+        return title.strip()[:255]
+
+    @staticmethod
+    def _validate_mode(mode: Optional[str]) -> str:
+        if mode is None:
+            return ChatSessionModeEnum.ASK.value
+        if mode not in {e.value for e in ChatSessionModeEnum}:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="INVALID_ARGUMENT: mode must be one of ask|assist|agent",
+            )
+        return mode
+
+    @staticmethod
+    def _validate_float_range(name: str, value: float, min_value: float, max_value: float, inclusive_min: bool, inclusive_max: bool) -> None:
+        if inclusive_min:
+            too_low = value < min_value
+        else:
+            too_low = value <= min_value
+        if inclusive_max:
+            too_high = value > max_value
+        else:
+            too_high = value >= max_value
+        if too_low or too_high:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"INVALID_ARGUMENT: {name} out of range",
+            )
+
+    def _normalize_defaults(self, defaults: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        normalized = deepcopy(DEFAULT_DEFAULTS)
+        if defaults is None:
+            return normalized
+
+        if not isinstance(defaults, dict):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="INVALID_ARGUMENT: defaults must be an object",
+            )
+
+        if "model" in defaults and defaults["model"] is not None:
+            model_name = defaults["model"]
+            if model_name not in ALLOWED_MODELS:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="INVALID_ARGUMENT: model not allowed",
+                )
+            normalized["model"] = model_name
+
+        if "temperature" in defaults and defaults["temperature"] is not None:
+            temperature = float(defaults["temperature"])
+            self._validate_float_range("temperature", temperature, 0.0, 2.0, True, True)
+            normalized["temperature"] = temperature
+
+        if "top_p" in defaults and defaults["top_p"] is not None:
+            top_p = float(defaults["top_p"])
+            self._validate_float_range("top_p", top_p, 0.0, 1.0, False, True)
+            normalized["top_p"] = top_p
+
+        if "system_prompt" in defaults:
+            normalized["system_prompt"] = defaults["system_prompt"]
+
+        if "retrieval" in defaults and defaults["retrieval"] is not None:
+            retrieval = defaults["retrieval"]
+            if not isinstance(retrieval, dict):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="INVALID_ARGUMENT: retrieval must be an object",
+                )
+            if "enabled" in retrieval and retrieval["enabled"] is not None:
+                normalized["retrieval"]["enabled"] = bool(retrieval["enabled"])
+            if "top_k" in retrieval and retrieval["top_k"] is not None:
+                top_k = int(retrieval["top_k"])
+                if top_k < 1:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="INVALID_ARGUMENT: retrieval.top_k must be >= 1",
+                    )
+                normalized["retrieval"]["top_k"] = top_k
+            if "rerank" in retrieval and retrieval["rerank"] is not None:
+                normalized["retrieval"]["rerank"] = bool(retrieval["rerank"])
+
+        return normalized
+
+    async def _validate_context(
+        self,
+        workspace_id: int,
+        context: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        if context is None:
+            return {
+                "note_id": None,
+                "anchor_ids": [],
+                "doc_id": None,
+                "doc_anchor_ids": [],
+            }
+        if not isinstance(context, dict):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="INVALID_ARGUMENT: context must be an object",
+            )
+
+        note_id = context.get("note_id")
+        doc_id = context.get("doc_id")
+        anchor_ids = context.get("anchor_ids") or []
+        doc_anchor_ids = context.get("doc_anchor_ids") or []
+
+        if doc_anchor_ids and doc_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="INVALID_ARGUMENT: doc_anchor_ids requires doc_id",
+            )
+
+        if anchor_ids and not isinstance(anchor_ids, list):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="INVALID_ARGUMENT: anchor_ids must be a list",
+            )
+        if doc_anchor_ids and not isinstance(doc_anchor_ids, list):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="INVALID_ARGUMENT: doc_anchor_ids must be a list",
+            )
+
+        if note_id is not None:
+            note = await self._get_note(int(note_id))
+            if note is None or note.workspace_id != workspace_id:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="NOTE_NOT_FOUND: Note not found",
+                )
+            if doc_id is not None and note.doc_id is not None and note.doc_id != int(doc_id):
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="NOTE_DOC_MISMATCH: Note does not belong to document",
+                )
+
+        if doc_id is not None:
+            doc = await self._get_doc(int(doc_id))
+            if doc is None or doc.workspace_id != workspace_id:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="DOC_NOT_FOUND: Document not found",
+                )
+
+        anchor_map = await self._load_anchors(anchor_ids)
+        for anchor in anchor_map.values():
+            if anchor.workspace_id != workspace_id:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="ANCHOR_INVALID: Anchor not in workspace",
+                )
+            if note_id is not None and anchor.note_id != int(note_id):
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="ANCHOR_INVALID: Anchor not associated with note",
+                )
+
+        doc_anchor_map = await self._load_anchors(doc_anchor_ids)
+        for anchor in doc_anchor_map.values():
+            if anchor.workspace_id != workspace_id:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="ANCHOR_INVALID: Anchor not in workspace",
+                )
+            if doc_id is not None and anchor.doc_id != int(doc_id):
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="ANCHOR_INVALID: Anchor not associated with document",
+                )
+
+        return {
+            "note_id": int(note_id) if note_id is not None else None,
+            "anchor_ids": [int(anchor_id) for anchor_id in anchor_ids],
+            "doc_id": int(doc_id) if doc_id is not None else None,
+            "doc_anchor_ids": [int(anchor_id) for anchor_id in doc_anchor_ids],
+        }
+
+    async def create_session(
+        self,
+        workspace_id: int,
+        user_id: int,
+        title: Optional[str],
+        mode: Optional[str],
+        context: Optional[Dict[str, Any]],
+        defaults: Optional[Dict[str, Any]],
+        client_request_id: Optional[str],
+    ) -> ChatSessionModel:
+        try:
+            workspace = await self._get_workspace(workspace_id)
+            if workspace is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="WORKSPACE_NOT_FOUND: Workspace not found",
+                )
+
+            has_access = await check_workspace_membership(workspace_id, user_id, self.db_session)
+            if not has_access:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="FORBIDDEN: No permission to access workspace",
+                )
+
+            normalized_title = self._normalize_title(title)
+            normalized_mode = self._validate_mode(mode)
+            normalized_defaults = self._normalize_defaults(defaults)
+            normalized_context = await self._validate_context(workspace_id, context)
+
+            normalized_client_request_id = client_request_id.strip() if client_request_id else None
+            if normalized_client_request_id:
+                existing_query = select(ChatSessionModel).where(
+                    ChatSessionModel.workspace_id == workspace_id,
+                    ChatSessionModel.client_request_id == normalized_client_request_id,
+                )
+                result = await self.db_session.execute(existing_query)
+                existing = result.scalar_one_or_none()
+                if existing is not None:
+                    if existing.owner_user_id != user_id:
+                        raise HTTPException(
+                            status_code=status.HTTP_409_CONFLICT,
+                            detail="CLIENT_REQUEST_ID_CONFLICT: client_request_id already used",
+                        )
+                    return existing
+
+            session_model = ChatSessionModel(
+                workspace_id=workspace_id,
+                owner_user_id=user_id,
+                title=normalized_title,
+                mode=normalized_mode,
+                context_json=normalized_context,
+                defaults_json=normalized_defaults,
+                client_request_id=normalized_client_request_id,
+            )
+
+            self.db_session.add(session_model)
+            await self.db_session.commit()
+            await self.db_session.refresh(session_model)
+
+            logger.info(
+                "Chat session created: session_id=%s, workspace_id=%s, user_id=%s",
+                session_model.session_id,
+                workspace_id,
+                user_id,
+            )
+
+            return session_model
+
+        except HTTPException:
+            await self.db_session.rollback()
+            raise
+        except Exception as exc:
+            await self.db_session.rollback()
+            logger.error("Chat session creation failed: %s", exc)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="INTERNAL_ERROR: An unexpected error occurred",
+            )

--- a/src/pdf_ai_agent/config/database/models/__init__.py
+++ b/src/pdf_ai_agent/config/database/models/__init__.py
@@ -43,6 +43,7 @@ from pdf_ai_agent.config.database.models.model_document import (
     MessageModel,
     JobModel,
     DocStatus,
+    ChatSessionModeEnum,
     RoleEnum,
     JobTypeEnum,
     JobStatusEnum,
@@ -72,6 +73,7 @@ __all__ = [
     "JobModel",
     # Enums
     "DocStatus",
+    "ChatSessionModeEnum",
     "RoleEnum",
     "JobTypeEnum",
     "JobStatusEnum",

--- a/test/integration_test/test_chat_sessions_create.py
+++ b/test/integration_test/test_chat_sessions_create.py
@@ -1,0 +1,204 @@
+"""Integration tests for chat session creation endpoint."""
+import pytest
+from contextlib import asynccontextmanager
+from httpx import ASGITransport, AsyncClient
+from fastapi import FastAPI
+
+from pdf_ai_agent.api.routes.chat_sessions import router as chat_sessions_router
+from pdf_ai_agent.config.database.models.model_user import UserModel, WorkspaceModel
+from pdf_ai_agent.config.database.models.model_document import DocsModel, NoteModel, AnchorModel
+
+
+@pytest.fixture
+async def test_user(db_session):
+    user = UserModel(
+        username="testuser",
+        email="test@example.com",
+        full_name="Test User",
+        is_active=True,
+        email_verified=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+async def test_workspace(db_session, test_user):
+    workspace = WorkspaceModel(
+        name="Test Workspace",
+        owner_user_id=test_user.user_id,
+    )
+    db_session.add(workspace)
+    await db_session.commit()
+    await db_session.refresh(workspace)
+    return workspace
+
+
+@pytest.fixture
+async def test_doc(db_session, test_workspace, test_user):
+    doc = DocsModel(
+        workspace_id=test_workspace.workspace_id,
+        owner_user_id=test_user.user_id,
+        filename="test.pdf",
+        storage_uri="file:///tmp/test.pdf",
+        file_type="application/pdf",
+        file_size=2345678,
+        file_sha256="a" * 64,
+        title="Test Document",
+        status="ready",
+    )
+    db_session.add(doc)
+    await db_session.commit()
+    await db_session.refresh(doc)
+    return doc
+
+
+@pytest.fixture
+async def test_note(db_session, test_workspace, test_user):
+    note = NoteModel(
+        workspace_id=test_workspace.workspace_id,
+        doc_id=None,
+        owner_user_id=test_user.user_id,
+        title="Test Note",
+        markdown="Sample",
+    )
+    db_session.add(note)
+    await db_session.commit()
+    await db_session.refresh(note)
+    return note
+
+
+@pytest.fixture
+async def test_anchor(db_session, test_workspace, test_user, test_doc, test_note):
+    anchor = AnchorModel(
+        created_by_user_id=test_user.user_id,
+        note_id=test_note.note_id,
+        doc_id=test_doc.doc_id,
+        chunk_id=None,
+        workspace_id=test_workspace.workspace_id,
+        page=1,
+        quoted_text="quote",
+        locator={"type": "pdf_quadpoints"},
+        locator_hash="hash_anchor_int_1",
+    )
+    db_session.add(anchor)
+    await db_session.commit()
+    await db_session.refresh(anchor)
+    return anchor
+
+
+@pytest.fixture
+async def test_app(db_session):
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        from pdf_ai_agent.config.database.init_database import get_database_config, init_database, close_engine
+
+        config = get_database_config()
+        await init_database(config)
+        yield
+        await close_engine()
+
+    app = FastAPI(title="PDF_Agent", lifespan=lifespan)
+    app.include_router(chat_sessions_router)
+
+    from pdf_ai_agent.config.database.init_database import get_db_session
+
+    async def override_get_db_session():
+        yield db_session
+
+    app.dependency_overrides[get_db_session] = override_get_db_session
+    return app
+
+
+class TestChatSessionCreateAPI:
+    @pytest.mark.asyncio
+    async def test_create_chat_session_success(self, test_app, test_user, test_workspace, test_doc, test_note, test_anchor):
+        transport = ASGITransport(app=test_app)
+        payload = {
+            "title": "New chat",
+            "mode": "assist",
+            "context": {
+                "note_id": test_note.note_id,
+                "anchor_ids": [test_anchor.anchor_id],
+                "doc_id": test_doc.doc_id,
+            },
+            "defaults": {
+                "model": "gpt-4.1-mini",
+                "temperature": 0.2,
+                "top_p": 1.0,
+                "retrieval": {"enabled": True, "top_k": 8, "rerank": False},
+            },
+        }
+
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/api/workspaces/{test_workspace.workspace_id}/chat/sessions",
+                params={"user_id": test_user.user_id},
+                json=payload,
+            )
+
+        assert response.status_code == 201
+        data = response.json()["session"]
+        assert data["workspace_id"] == test_workspace.workspace_id
+        assert data["mode"] == "assist"
+        assert data["context"]["note_id"] == test_note.note_id
+        assert data["context"]["anchor_ids"] == [test_anchor.anchor_id]
+        assert data["defaults"]["model"] == "gpt-4.1-mini"
+
+    @pytest.mark.asyncio
+    async def test_create_chat_session_forbidden(self, test_app, db_session, test_user):
+        other_user = UserModel(
+            username="other",
+            email="other@example.com",
+            is_active=True,
+        )
+        db_session.add(other_user)
+        await db_session.commit()
+        await db_session.refresh(other_user)
+
+        other_workspace = WorkspaceModel(
+            name="Other Workspace",
+            owner_user_id=other_user.user_id,
+        )
+        db_session.add(other_workspace)
+        await db_session.commit()
+        await db_session.refresh(other_workspace)
+
+        transport = ASGITransport(app=test_app)
+
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/api/workspaces/{other_workspace.workspace_id}/chat/sessions",
+                params={"user_id": test_user.user_id},
+                json={"mode": "ask"},
+            )
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_create_chat_session_doc_not_found(self, test_app, test_user, test_workspace):
+        transport = ASGITransport(app=test_app)
+
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/api/workspaces/{test_workspace.workspace_id}/chat/sessions",
+                params={"user_id": test_user.user_id},
+                json={"mode": "ask", "context": {"doc_id": 99999}},
+            )
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_create_chat_session_anchor_invalid(self, test_app, test_user, test_workspace):
+        transport = ASGITransport(app=test_app)
+
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/api/workspaces/{test_workspace.workspace_id}/chat/sessions",
+                params={"user_id": test_user.user_id},
+                json={"mode": "ask", "context": {"anchor_ids": [99999]}},
+            )
+
+        assert response.status_code == 422

--- a/test/unit_test/test_chat_session_service.py
+++ b/test/unit_test/test_chat_session_service.py
@@ -1,0 +1,223 @@
+"""Unit tests for chat session service."""
+import pytest
+from fastapi import HTTPException
+
+from pdf_ai_agent.api.services.chat_session_service import ChatSessionService
+from pdf_ai_agent.config.database.models.model_user import UserModel, WorkspaceModel
+from pdf_ai_agent.config.database.models.model_document import DocsModel, NoteModel, AnchorModel
+
+
+@pytest.fixture
+async def test_user(db_session):
+    user = UserModel(
+        username="testuser",
+        email="test@example.com",
+        full_name="Test User",
+        is_active=True,
+        email_verified=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+async def test_workspace(db_session, test_user):
+    workspace = WorkspaceModel(
+        name="Test Workspace",
+        owner_user_id=test_user.user_id,
+    )
+    db_session.add(workspace)
+    await db_session.commit()
+    await db_session.refresh(workspace)
+    return workspace
+
+
+@pytest.fixture
+async def test_doc(db_session, test_user, test_workspace):
+    doc = DocsModel(
+        workspace_id=test_workspace.workspace_id,
+        owner_user_id=test_user.user_id,
+        filename="test.pdf",
+        storage_uri="file:///tmp/test.pdf",
+        file_type="application/pdf",
+        file_size=1024,
+        file_sha256="a" * 64,
+        title="Test Document",
+        status="ready",
+    )
+    db_session.add(doc)
+    await db_session.commit()
+    await db_session.refresh(doc)
+    return doc
+
+
+@pytest.fixture
+async def test_note(db_session, test_user, test_workspace):
+    note = NoteModel(
+        workspace_id=test_workspace.workspace_id,
+        doc_id=None,
+        owner_user_id=test_user.user_id,
+        title="Test Note",
+        markdown="Some content",
+    )
+    db_session.add(note)
+    await db_session.commit()
+    await db_session.refresh(note)
+    return note
+
+
+@pytest.fixture
+async def test_anchor(db_session, test_user, test_workspace, test_doc, test_note):
+    anchor = AnchorModel(
+        created_by_user_id=test_user.user_id,
+        note_id=test_note.note_id,
+        doc_id=test_doc.doc_id,
+        chunk_id=None,
+        workspace_id=test_workspace.workspace_id,
+        page=1,
+        quoted_text="quote",
+        locator={"type": "pdf_quadpoints"},
+        locator_hash="hash_anchor_1",
+    )
+    db_session.add(anchor)
+    await db_session.commit()
+    await db_session.refresh(anchor)
+    return anchor
+
+
+@pytest.fixture
+async def test_doc_anchor(db_session, test_user, test_workspace, test_doc):
+    anchor = AnchorModel(
+        created_by_user_id=test_user.user_id,
+        note_id=None,
+        doc_id=test_doc.doc_id,
+        chunk_id=None,
+        workspace_id=test_workspace.workspace_id,
+        page=2,
+        quoted_text="doc quote",
+        locator={"type": "pdf_quadpoints"},
+        locator_hash="hash_anchor_2",
+    )
+    db_session.add(anchor)
+    await db_session.commit()
+    await db_session.refresh(anchor)
+    return anchor
+
+
+class TestChatSessionService:
+    @pytest.mark.asyncio
+    async def test_create_session_success_defaults(self, db_session, test_user, test_workspace):
+        service = ChatSessionService(db_session=db_session)
+
+        session = await service.create_session(
+            workspace_id=test_workspace.workspace_id,
+            user_id=test_user.user_id,
+            title=None,
+            mode=None,
+            context=None,
+            defaults=None,
+            client_request_id=None,
+        )
+
+        assert session.session_id is not None
+        assert session.title == "New chat"
+        assert session.mode.value == "ask"
+        assert session.defaults_json["model"] == "gpt-4.1-mini"
+        assert session.defaults_json["temperature"] == 0.2
+        assert session.defaults_json["top_p"] == 1.0
+        assert session.context_json["note_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_create_session_invalid_mode(self, db_session, test_user, test_workspace):
+        service = ChatSessionService(db_session=db_session)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.create_session(
+                workspace_id=test_workspace.workspace_id,
+                user_id=test_user.user_id,
+                title=None,
+                mode="invalid",
+                context=None,
+                defaults=None,
+                client_request_id=None,
+            )
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_create_session_invalid_defaults(self, db_session, test_user, test_workspace):
+        service = ChatSessionService(db_session=db_session)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.create_session(
+                workspace_id=test_workspace.workspace_id,
+                user_id=test_user.user_id,
+                title=None,
+                mode="ask",
+                context=None,
+                defaults={"temperature": -0.1},
+                client_request_id=None,
+            )
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_create_session_context_anchor_validation(
+        self,
+        db_session,
+        test_user,
+        test_workspace,
+        test_doc,
+        test_note,
+        test_anchor,
+    ):
+        service = ChatSessionService(db_session=db_session)
+
+        session = await service.create_session(
+            workspace_id=test_workspace.workspace_id,
+            user_id=test_user.user_id,
+            title="Session",
+            mode="assist",
+            context={
+                "note_id": test_note.note_id,
+                "anchor_ids": [test_anchor.anchor_id],
+                "doc_id": test_doc.doc_id,
+            },
+            defaults=None,
+            client_request_id=None,
+        )
+
+        assert session.context_json["note_id"] == test_note.note_id
+        assert session.context_json["anchor_ids"] == [test_anchor.anchor_id]
+
+    @pytest.mark.asyncio
+    async def test_create_session_idempotency(
+        self,
+        db_session,
+        test_user,
+        test_workspace,
+    ):
+        service = ChatSessionService(db_session=db_session)
+
+        first = await service.create_session(
+            workspace_id=test_workspace.workspace_id,
+            user_id=test_user.user_id,
+            title=None,
+            mode="ask",
+            context=None,
+            defaults=None,
+            client_request_id="req-123",
+        )
+        second = await service.create_session(
+            workspace_id=test_workspace.workspace_id,
+            user_id=test_user.user_id,
+            title="Another",
+            mode="assist",
+            context=None,
+            defaults=None,
+            client_request_id="req-123",
+        )
+
+        assert first.session_id == second.session_id


### PR DESCRIPTION
Fixes #41.

User impact:
Before: no API to create chat sessions with mode/context/defaults.
After: clients can create sessions via `POST /api/workspaces/{workspace_id}/chat/sessions` with validation, idempotency, and structured response.

Root cause:
The chat session endpoint and supporting schema/validation/service logic were missing, and the session model lacked required fields (mode/context/defaults/title).

Fix details:
- Added chat session schema/models and database fields for mode/context/defaults/title/client_request_id.
- Implemented chat session service with validation (mode/defaults/context), idempotency, and workspace access checks.
- Added route wiring and FastAPI router registration.
- Added unit and integration tests for creation, validation, and permissions.

Tests:
- `uv run pytest test/unit_test/test_chat_session_service.py -v`
- `uv run pytest test/integration_test/test_chat_sessions_create.py -v`
