### PR TITLE
[codex] pdf-chat-bot-mvp-endpoint-5-send-message-ask

### DIFF
--- a/src/pdf_ai_agent/api/schemas/chat_schemas.py
+++ b/src/pdf_ai_agent/api/schemas/chat_schemas.py
@@ -104,6 +104,7 @@ class MessageItem(BaseModel):
     role: str = Field(..., description="Message role")
     content: List[MessageContentItem] = Field(..., description="Message content blocks")
     citations: Optional[List[dict]] = Field(None, description="Citations")
+    usage: Optional[dict] = Field(None, description="Token usage metadata")
     created_at: datetime = Field(..., description="Message creation timestamp")
 
 
@@ -165,3 +166,32 @@ class ChatErrorDetail(BaseModel):
 class ChatErrorResponse(BaseModel):
     """Error response schema."""
     error: ChatErrorDetail = Field(..., description="Error details")
+
+
+class ChatOverridesRetrieval(BaseModel):
+    """Overrides for retrieval settings."""
+    enabled: Optional[bool] = Field(None, description="Enable retrieval")
+    top_k: Optional[int] = Field(None, description="Number of chunks to retrieve")
+    rerank: Optional[bool] = Field(None, description="Enable reranking")
+
+
+class ChatOverrides(BaseModel):
+    """Overrides for a single request."""
+    model: Optional[str] = Field(None, description="Override model name")
+    temperature: Optional[float] = Field(None, description="Override sampling temperature")
+    top_p: Optional[float] = Field(None, description="Override top-p sampling")
+    retrieval: Optional[ChatOverridesRetrieval] = Field(None, description="Override retrieval settings")
+
+
+class AskMessageRequest(BaseModel):
+    """Request schema for ask message."""
+    client_request_id: str = Field(..., description="Client request ID for idempotency", min_length=1)
+    input: List[MessageContentItem] = Field(..., description="Structured input content")
+    context: Optional[ChatSessionContext] = Field(None, description="Optional context override")
+    overrides: Optional[ChatOverrides] = Field(None, description="Optional overrides for this request")
+
+
+class AskMessageResponse(BaseModel):
+    """Response schema for ask message."""
+    user_message: MessageItem = Field(..., description="User message")
+    assistant_message: MessageItem = Field(..., description="Assistant message")

--- a/src/pdf_ai_agent/api/services/chat_session_service.py
+++ b/src/pdf_ai_agent/api/services/chat_session_service.py
@@ -501,8 +501,7 @@ class ChatSessionService:
                 is_new_user_message = True
 
             anchor_ids = normalized_context.get("anchor_ids") or []
-            doc_anchor_ids = normalized_context.get("doc_anchor_ids") or []
-            anchor_map = await self._load_anchors(list({*anchor_ids, *doc_anchor_ids}))
+            anchor_map = await self._load_anchors(list({*anchor_ids}))
             citations = self._build_citations(list(anchor_map.values()))
 
             assistant_text = (

--- a/src/pdf_ai_agent/api/services/chat_session_service.py
+++ b/src/pdf_ai_agent/api/services/chat_session_service.py
@@ -82,7 +82,7 @@ class ChatSessionService:
         anchors = result.scalars().all()
         if len(anchors) != len(anchor_list):
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail="ANCHOR_INVALID: One or more anchors not found",
             )
         return {anchor.anchor_id: anchor for anchor in anchors}
@@ -219,7 +219,7 @@ class ChatSessionService:
                 )
             if doc_id is not None and note.doc_id is not None and note.doc_id != int(doc_id):
                 raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                     detail="NOTE_DOC_MISMATCH: Note does not belong to document",
                 )
 
@@ -235,12 +235,12 @@ class ChatSessionService:
         for anchor in anchor_map.values():
             if anchor.workspace_id != workspace_id:
                 raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                     detail="ANCHOR_INVALID: Anchor not in workspace",
                 )
             if note_id is not None and anchor.note_id != int(note_id):
                 raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                     detail="ANCHOR_INVALID: Anchor not associated with note",
                 )
 
@@ -248,12 +248,12 @@ class ChatSessionService:
         for anchor in doc_anchor_map.values():
             if anchor.workspace_id != workspace_id:
                 raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                     detail="ANCHOR_INVALID: Anchor not in workspace",
                 )
             if doc_id is not None and anchor.doc_id != int(doc_id):
                 raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                     detail="ANCHOR_INVALID: Anchor not associated with document",
                 )
 

--- a/test/unit_test/test_chat_session_service.py
+++ b/test/unit_test/test_chat_session_service.py
@@ -108,6 +108,23 @@ async def test_doc_anchor(db_session, test_user, test_workspace, test_doc):
 
 class TestChatSessionService:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", ["ask", "assist", "agent"])
+    async def test_create_session_valid_modes(self, db_session, test_user, test_workspace, mode):
+        service = ChatSessionService(db_session=db_session)
+
+        session = await service.create_session(
+            workspace_id=test_workspace.workspace_id,
+            user_id=test_user.user_id,
+            title=None,
+            mode=mode,
+            context=None,
+            defaults=None,
+            client_request_id=None,
+        )
+
+        assert session.mode.value == mode
+
+    @pytest.mark.asyncio
     async def test_create_session_success_defaults(self, db_session, test_user, test_workspace):
         service = ChatSessionService(db_session=db_session)
 
@@ -164,6 +181,41 @@ class TestChatSessionService:
         assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
+    async def test_create_session_defaults_boundary(self, db_session, test_user, test_workspace):
+        service = ChatSessionService(db_session=db_session)
+
+        session = await service.create_session(
+            workspace_id=test_workspace.workspace_id,
+            user_id=test_user.user_id,
+            title=None,
+            mode="ask",
+            context=None,
+            defaults={"temperature": 0.0, "top_p": 1.0, "retrieval": {"top_k": 1}},
+            client_request_id=None,
+        )
+
+        assert session.defaults_json["temperature"] == 0.0
+        assert session.defaults_json["top_p"] == 1.0
+        assert session.defaults_json["retrieval"]["top_k"] == 1
+
+    @pytest.mark.asyncio
+    async def test_create_session_defaults_top_p_zero_invalid(self, db_session, test_user, test_workspace):
+        service = ChatSessionService(db_session=db_session)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.create_session(
+                workspace_id=test_workspace.workspace_id,
+                user_id=test_user.user_id,
+                title=None,
+                mode="ask",
+                context=None,
+                defaults={"top_p": 0.0},
+                client_request_id=None,
+            )
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
     async def test_create_session_context_anchor_validation(
         self,
         db_session,
@@ -191,6 +243,109 @@ class TestChatSessionService:
 
         assert session.context_json["note_id"] == test_note.note_id
         assert session.context_json["anchor_ids"] == [test_anchor.anchor_id]
+
+    @pytest.mark.asyncio
+    async def test_create_session_context_anchor_wrong_workspace(
+        self,
+        db_session,
+        test_user,
+        test_workspace,
+        test_doc,
+    ):
+        other_workspace = WorkspaceModel(
+            name="Other Workspace",
+            owner_user_id=test_user.user_id,
+        )
+        db_session.add(other_workspace)
+        await db_session.commit()
+        await db_session.refresh(other_workspace)
+
+        other_anchor = AnchorModel(
+            created_by_user_id=test_user.user_id,
+            note_id=None,
+            doc_id=test_doc.doc_id,
+            chunk_id=None,
+            workspace_id=other_workspace.workspace_id,
+            page=1,
+            quoted_text="quote",
+            locator={"type": "pdf_quadpoints"},
+            locator_hash="hash_anchor_other",
+        )
+        db_session.add(other_anchor)
+        await db_session.commit()
+        await db_session.refresh(other_anchor)
+
+        service = ChatSessionService(db_session=db_session)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.create_session(
+                workspace_id=test_workspace.workspace_id,
+                user_id=test_user.user_id,
+                title="Session",
+                mode="assist",
+                context={
+                    "doc_id": test_doc.doc_id,
+                    "doc_anchor_ids": [other_anchor.anchor_id],
+                },
+                defaults=None,
+                client_request_id=None,
+            )
+
+        assert exc_info.value.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_create_session_context_anchor_note_mismatch(
+        self,
+        db_session,
+        test_user,
+        test_workspace,
+        test_doc,
+        test_note,
+    ):
+        other_note = NoteModel(
+            workspace_id=test_workspace.workspace_id,
+            doc_id=None,
+            owner_user_id=test_user.user_id,
+            title="Other Note",
+            markdown="Other content",
+        )
+        db_session.add(other_note)
+        await db_session.commit()
+        await db_session.refresh(other_note)
+
+        anchor = AnchorModel(
+            created_by_user_id=test_user.user_id,
+            note_id=other_note.note_id,
+            doc_id=test_doc.doc_id,
+            chunk_id=None,
+            workspace_id=test_workspace.workspace_id,
+            page=1,
+            quoted_text="quote",
+            locator={"type": "pdf_quadpoints"},
+            locator_hash="hash_anchor_note_mismatch",
+        )
+        db_session.add(anchor)
+        await db_session.commit()
+        await db_session.refresh(anchor)
+
+        service = ChatSessionService(db_session=db_session)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.create_session(
+                workspace_id=test_workspace.workspace_id,
+                user_id=test_user.user_id,
+                title="Session",
+                mode="assist",
+                context={
+                    "note_id": test_note.note_id,
+                    "anchor_ids": [anchor.anchor_id],
+                    "doc_id": test_doc.doc_id,
+                },
+                defaults=None,
+                client_request_id=None,
+            )
+
+        assert exc_info.value.status_code == 422
 
     @pytest.mark.asyncio
     async def test_create_session_idempotency(


### PR DESCRIPTION
## What\nFixes #50 by adding the ask-message endpoint for chat sessions.\n\n## User Impact\nBefore: clients could not send ask messages or receive responses for a session.\nAfter: clients can POST an ask message, get a stored user+assistant pair, and optionally stream SSE deltas.\n\n## Root Cause\nThe ask-message endpoint and service flow were not implemented for chat sessions.\n\n## Fix Details\n- Added ask request/response schemas and override models.\n- Implemented service logic for validation, idempotency, message persistence, session counters, and placeholder assistant output.\n- Added SSE response flow with message.created, assistant.delta, and assistant.completed events.\n\n## Tests\n- uv run pytest test/unit_test/test_chat_session_service.py -v\n- uv run pytest test/integration_test/test_chat_sessions_create.py -v\n\n## Notes\n- Assistant responses are MVP placeholders; replace with real retrieval/LLM once available.