### PR TITLE
[codex] pdf-chat-bot-mvp-endpoint-6-send-message-assist-agent

### DIFF
--- a/src/pdf_ai_agent/api/schemas/chat_schemas.py
+++ b/src/pdf_ai_agent/api/schemas/chat_schemas.py
@@ -15,9 +15,8 @@ class ChatSessionMode(str, Enum):
 class ChatSessionContext(BaseModel):
     """Context for a chat session."""
     note_id: Optional[int] = Field(None, description="Note ID")
-    anchor_ids: Optional[List[int]] = Field(None, description="Anchor IDs for note context")
+    anchor_ids: Optional[List[int]] = Field(None, description="Anchor IDs for document context")
     doc_id: Optional[int] = Field(None, description="Document ID")
-    doc_anchor_ids: Optional[List[int]] = Field(None, description="Anchor IDs for document context")
 
 
 class RetrievalDefaults(BaseModel):

--- a/src/pdf_ai_agent/api/services/chat_session_service.py
+++ b/src/pdf_ai_agent/api/services/chat_session_service.py
@@ -754,6 +754,7 @@ class ChatSessionService:
             }
             request_hash = self._compute_request_hash(request_payload)
 
+            # Check the request idempotency
             existing_query = select(MessageModel).where(
                 MessageModel.session_id == session_id,
                 MessageModel.workspace_id == workspace_id,
@@ -763,6 +764,7 @@ class ChatSessionService:
             existing_result = await self.db_session.execute(existing_query)
             existing_user_message = existing_result.scalar_one_or_none()
             if existing_user_message is not None:
+                # If the user message exist, return existing one
                 existing_context = existing_user_message.context or {}
                 if existing_context.get("request_hash") != request_hash:
                     raise HTTPException(
@@ -783,6 +785,7 @@ class ChatSessionService:
                 user_message = existing_user_message
                 is_new_user_message = False
             else:
+                # if user message doesn't exist, add a new one to the database
                 user_message = MessageModel(
                     session_id=session_id,
                     workspace_id=workspace_id,
@@ -832,6 +835,7 @@ class ChatSessionService:
                         detail="REVISION_CONFLICT: base_revision mismatch",
                     )
 
+                # LLM生成的结构化内容placeholder
                 patch_content = self._build_assist_patch_content(note.markdown or "", input_text)
                 self._validate_note_patch_parsimony(note.markdown or "", patch_content)
 


### PR DESCRIPTION
## What issue this fixes
- Fixes #52

## User impact
- Before: no assist/agent send-message endpoint or note patch handling.
- After: `/message:assist` supports structured input, optional note patch preview/auto, SSE events, and persists user/assistant messages with metadata.

## Root cause
- The assist/agent send-message flow was not implemented.

## Fix details
- Added assist request/response schemas and note patch payloads.
- Implemented assist message service with idempotency, note patch validation/application, and citations.
- Added assist endpoint route with SSE event sequence.
- Added unit tests for assist preview and revision conflict.

## Tests run
- uv run pytest test/unit_test/test_chat_session_service.py -v
